### PR TITLE
add missing include (for FTBFS with gcc-11)

### DIFF
--- a/include/mizugaki/ast/scalar/builtin_set_function_invocation.h
+++ b/include/mizugaki/ast/scalar/builtin_set_function_invocation.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <optional>
+
 #include <takatori/util/clone_tag.h>
 
 #include <mizugaki/ast/common/regioned.h>


### PR DESCRIPTION
g++-11 で使用する libstdc++ でヘッダファイルの依存関係が変更となり、
`#include` を省略していたもののコンパイルが通らなくなることがあります。

参考:
https://gcc.gnu.org/gcc-11/porting_to.html#header-dep-changes

これへの対応となります。

Issue: https://github.com/project-tsurugi/tsurugi-issues/issues/274