### PR TITLE
support remainder (`%`) operator syntax.

### DIFF
--- a/include/mizugaki/ast/scalar/binary_operator.h
+++ b/include/mizugaki/ast/scalar/binary_operator.h
@@ -43,6 +43,12 @@ enum class binary_operator {
     solidus,
 
     /**
+     * @brief percent (`%`).
+     * @note Tsurugi extension - numeric remainder operator.
+     */
+    percent,
+
+    /**
      * @brief concatenation operator (`||`).
      * @note `6.27 <string value expression>`
      * @note `6.31 <array value expression>`
@@ -136,6 +142,7 @@ inline constexpr std::string_view to_string_view(binary_operator value) noexcept
         case kind::minus: return "minus"sv;
         case kind::asterisk: return "asterisk"sv;
         case kind::solidus: return "solidus"sv;
+        case kind::percent: return "percent"sv;
         case kind::concatenation: return "concatenation"sv;
         case kind::element_reference: return "element_reference"sv;
         case kind::at_time_zone: return "at_time_zone"sv;

--- a/src/mizugaki/analyzer/details/analyze_scalar_expression.cpp
+++ b/src/mizugaki/analyzer/details/analyze_scalar_expression.cpp
@@ -239,6 +239,8 @@ public:
                 return to::multiply;
             case from::solidus:
                 return to::divide;
+            case from::percent:
+                return to::remainder;
             case from::concatenation:
                 return to::concat;
             case from::and_:

--- a/src/mizugaki/parser/sql_parser.yy
+++ b/src/mizugaki/parser/sql_parser.yy
@@ -897,7 +897,7 @@
 
 // value expression
 %left "+" "-" "||"
-%left "*" "/"
+%left "*" "/" "%"
 %precedence UNARY_PLUS UNARY_MINUS
 
 %start program
@@ -2814,6 +2814,14 @@ scalar_value_expression
             $$ = driver.node<ast::scalar::binary_expression>(
                     $l,
                     regioned { ast::scalar::binary_operator::solidus, @o },
+                    $r,
+                    @$);
+        }
+    | scalar_value_expression[l] "%"[o] scalar_value_expression[r]
+        {
+            $$ = driver.node<ast::scalar::binary_expression>(
+                    $l,
+                    regioned { ast::scalar::binary_operator::percent, @o },
                     $r,
                     @$);
         }

--- a/test/mizugaki/analyzer/details/analyze_scalar_expression_test.cpp
+++ b/test/mizugaki/analyzer/details/analyze_scalar_expression_test.cpp
@@ -281,6 +281,26 @@ TEST_F(analyze_scalar_expression_test, binary_expression_solidus) {
     }));
 }
 
+TEST_F(analyze_scalar_expression_test, binary_expression_percent) {
+    auto from = ast::scalar::binary_operator::percent;
+    auto to = tscalar::binary_operator::remainder;
+    auto r = analyze_scalar_expression(
+            context(),
+            ast::scalar::binary_expression {
+                    literal(number("1")),
+                    from,
+                    literal(number("2")),
+            },
+            {},
+            {});
+    ASSERT_TRUE(r);
+    EXPECT_EQ(*r, (tscalar::binary {
+            to,
+            immediate(1),
+            immediate(2),
+    }));
+}
+
 TEST_F(analyze_scalar_expression_test, binary_expression_concatenation) {
     auto from = ast::scalar::binary_operator::concatenation;
     auto to = tscalar::binary_operator::concat;

--- a/test/mizugaki/parser/sql_parser_scalar_test.cpp
+++ b/test/mizugaki/parser/sql_parser_scalar_test.cpp
@@ -397,6 +397,17 @@ TEST_F(sql_parser_scalar_test, binary_expression_solidus) {
     }));
 }
 
+TEST_F(sql_parser_scalar_test, binary_expression_percent) {
+    auto result = parse("a % b");
+    ASSERT_TRUE(result) << diagnostics(result);
+
+    EXPECT_EQ(extract(result), (scalar::binary_expression {
+            v("a"),
+            scalar::binary_operator::percent,
+            v("b"),
+    }));
+}
+
 TEST_F(sql_parser_scalar_test, binary_expression_concatenation) {
     auto result = parse("a || b");
     ASSERT_TRUE(result) << diagnostics(result);


### PR DESCRIPTION
This PR introduces numeric binary remainder (`%`) operator syntax.

FYI, this syntax is not compliant to ANSI SQL.