### PR TITLE
misc: revise examples/parser-cli for parser performance tracking.

### DIFF
--- a/examples/parser-cli/CMakeLists.txt
+++ b/examples/parser-cli/CMakeLists.txt
@@ -38,5 +38,5 @@ endif()
 
 add_test(
     NAME parser-cli
-    COMMAND ${output_name} "SELECT * FROM T0;"
+    COMMAND ${output_name} "-text" "SELECT * FROM T0;"
 )

--- a/examples/parser-cli/README.md
+++ b/examples/parser-cli/README.md
@@ -3,13 +3,17 @@
 Parses SQL program and prints its syntactic structure as JSON format.
 
 ```sh
-mizugaki-parser-cli [options] [--] sql-program
+mizugaki-parser-cli [options]
 ```
 
 Please take care that each SQL statement must end with `;`, like `"SELECT * FROM T0;"`.
 
 Available options:
 
+* `-text <source text>`
+  * parses the given text
+* `-file <source file>`
+  * parses the content of the given file
 * `-quiet`
   * only show erroneous messages
 * `-repeat N`
@@ -29,24 +33,27 @@ Please build this project with `-DINSTALL_EXAMPLES=ON` option, then `cmake --bui
 
 ```sh
 # parse a statement
-mizugaki-parser-cli "SELECT * FROM T0;"
+./mizugaki-parser-cli -text "SELECT * FROM T0;"
 
 # parse multiple statements
-mizugaki-parser-cli -- '
+./mizugaki-parser-cli -text -- '
 -- insert and select
 INSERT INTO T0 (C0, C1) VALUES (1, 2), (3, 4);
 SELECT * FROM T0;
 '
 
+# parse statements in file
+./mizugaki-parser-cli -file "example.sql"
+
 # parse a statement and pretty print by https://stedolan.github.io/jq/
-mizugaki-parser-cli "TABLE a;" | jq .
+./mizugaki-parser-cli -text "TABLE a;" | jq .
 
 # parse a wrong statement
-mizugaki-parser-cli "INSERT INTO T1 VALUES 1;"
+./mizugaki-parser-cli -text "INSERT INTO T1 VALUES 1;"
 
 # parse a statement 10,000 times without printing
-mizugaki-parser-cli -repeat 10000 -quiet "SELECT * FROM T0;"
+./mizugaki-parser-cli -repeat 10000 -quiet -text "SELECT * FROM T0;"
 
 # parse with tracing (require -DCMAKE_BUILD_TYPE=Debug)
-mizugaki-parser-cli -debug 1 "SELECT * FROM T0;"
+./mizugaki-parser-cli -debug 1 -text "SELECT * FROM T0;"
 ```

--- a/examples/parser-cli/main.cpp
+++ b/examples/parser-cli/main.cpp
@@ -1,5 +1,6 @@
 #include <gflags/gflags.h>
 
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <string_view>
@@ -33,16 +34,32 @@ using namespace mizugaki::examples::parser_cli;
 DEFINE_bool(quiet, false, "only show diagnostic erroneous"); // NOLINT
 DEFINE_int32(debug, 0, "parser debug level"); // NOLINT
 DEFINE_uint32(repeat, 1, "repeat parse operation"); // NOLINT
+DEFINE_string(file, "", "input file path"); // NOLINT
+DEFINE_string(text, "", "input text"); // NOLINT
 
 int main(int argc, char* argv[]) {
     gflags::SetUsageMessage("mizugaki SQL parser CLI");
     gflags::ParseCommandLineFlags(&argc, &argv, true);
-    if (argc != 2) {
+
+    if ((FLAGS_text.empty() && FLAGS_file.empty()) || (!FLAGS_text.empty() && !FLAGS_file.empty())) {
         gflags::ShowUsageWithFlags(argv[0]); // NOLINT
-        return -1;
+        return 1;
     }
 
-    std::string_view source { argv[1] }; // NOLINT
+    std::string source;
+    if (!FLAGS_text.empty()) {
+        source = FLAGS_text;
+    } else {
+        std::ifstream ifs { FLAGS_file };
+        if (ifs.fail()) {
+            std::cerr << "failed to open file: " << FLAGS_file << std::endl;
+            return 2;
+        }
+        source.assign(
+                std::istreambuf_iterator<char> { ifs },
+                std::istreambuf_iterator<char> {});
+        ifs.close();
+    }
     if (run(source, FLAGS_repeat, FLAGS_quiet, FLAGS_debug)) {
         return 0;
     }


### PR DESCRIPTION
This PR revises example application for testing parser bahaviors, in `examples/parser-cli`.

```sh
# Parse SQL written in large.txt
time examples/parser-cli/mizugaki-parser-cli -file large.txt -quiet

# Parse "SELECT * FROM t" 10,000 times
time examples/parser-cli/mizugaki-parser-cli -text "SELECT * FROM t" -repeat 10000
```
