### PR TITLE
build: `ENABLE_SHAKUJO=OFF` to disable shakujo translator.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,13 +17,15 @@ option(FORCE_INSTALL_RPATH "automatically add library directory of custom prefix
 
 option(ENABLE_COVERAGE "enable coverage on debug build" OFF)
 
+option(ENABLE_SHAKUJO "whether to enable shakujo translator" ON)
+
 include(GNUInstallDirs)
 include(force_install_rpath)
 
 find_package(takatori REQUIRED)
 find_package(yugawara REQUIRED)
 find_package(mpdecpp REQUIRED)
-find_package(shakujo REQUIRED)
+
 find_package(tsl-hopscotch-map 2.2 REQUIRED)
 find_package(FLEX REQUIRED)
 find_package(BISON 3.6 REQUIRED)
@@ -40,6 +42,10 @@ find_package(Boost 1.65
 
 find_package(Doxygen
     OPTIONAL_COMPONENTS dot)
+
+if (ENABLE_SHAKUJO)
+    find_package(shakujo REQUIRED)
+endif (ENABLE_SHAKUJO)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_EXTENSIONS OFF)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -180,23 +180,27 @@ add_library(mizugaki
     # common tools
     mizugaki/placeholder_map.cpp
     mizugaki/placeholder_entry.cpp
-
-    # shakujo IR translator
-    mizugaki/translator/shakujo_translator.cpp
-    mizugaki/translator/shakujo_translator_options.cpp
-    mizugaki/translator/shakujo_translator_result.cpp
-    mizugaki/translator/shakujo_translator_impl.cpp
-    mizugaki/translator/details/relation_info.cpp
-    mizugaki/translator/details/variable_scope.cpp
-    mizugaki/translator/details/type_info_translator.cpp
-    mizugaki/translator/details/value_info_translator.cpp
-    mizugaki/translator/details/type_translator.cpp
-    mizugaki/translator/details/scalar_expression_translator.cpp
-    mizugaki/translator/details/relation_expression_translator.cpp
-    mizugaki/translator/details/aggregate_analyzer.cpp
-    mizugaki/translator/details/dml_statement_translator.cpp
-    mizugaki/translator/details/ddl_statement_translator.cpp
 )
+
+if (ENABLE_SHAKUJO)
+    # shakujo IR translator
+    target_sources(mizugaki PRIVATE
+            mizugaki/translator/shakujo_translator.cpp
+            mizugaki/translator/shakujo_translator_options.cpp
+            mizugaki/translator/shakujo_translator_result.cpp
+            mizugaki/translator/shakujo_translator_impl.cpp
+            mizugaki/translator/details/relation_info.cpp
+            mizugaki/translator/details/variable_scope.cpp
+            mizugaki/translator/details/type_info_translator.cpp
+            mizugaki/translator/details/value_info_translator.cpp
+            mizugaki/translator/details/type_translator.cpp
+            mizugaki/translator/details/scalar_expression_translator.cpp
+            mizugaki/translator/details/relation_expression_translator.cpp
+            mizugaki/translator/details/aggregate_analyzer.cpp
+            mizugaki/translator/details/dml_statement_translator.cpp
+            mizugaki/translator/details/ddl_statement_translator.cpp
+    )
+endif (ENABLE_SHAKUJO)
 
 message(STATUS ${FLEX_INCLUDE_DIRS})
 
@@ -210,10 +214,13 @@ target_link_libraries(mizugaki
     PUBLIC mizugaki-api
     PUBLIC takatori
     PUBLIC yugawara
-    PUBLIC shakujo-model # FIXME:transitive
     PRIVATE tsl::hopscotch_map
     PRIVATE Threads::Threads
 )
+
+if (ENABLE_SHAKUJO)
+    target_link_libraries(mizugaki PUBLIC shakujo-model)
+endif (ENABLE_SHAKUJO)
 
 if (FORCE_INSTALL_RPATH)
     force_install_rpath(mizugaki)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -75,12 +75,14 @@ add_analyzer_test_executable(mizugaki/analyzer/details/analyze_statement_table_d
 add_analyzer_test_executable(mizugaki/analyzer/details/analyze_statement_index_definition_test.cpp)
 add_analyzer_test_executable(mizugaki/analyzer/details/set_function_processor_test.cpp)
 
-# shakujo IR translator
-add_test_executable(mizugaki/translator/shakujo_translator_test.cpp)
-add_test_executable(mizugaki/translator/details/type_info_translator_test.cpp)
-add_test_executable(mizugaki/translator/details/value_info_translator_test.cpp)
-add_test_executable(mizugaki/translator/details/type_translator_test.cpp)
-add_test_executable(mizugaki/translator/details/scalar_expression_translator_test.cpp)
-add_test_executable(mizugaki/translator/details/relation_expression_translator_test.cpp)
-add_test_executable(mizugaki/translator/details/dml_statement_translator_test.cpp)
-add_test_executable(mizugaki/translator/details/ddl_statement_translator_test.cpp)
+if (ENABLE_SHAKUJO)
+    # shakujo IR translator
+    add_test_executable(mizugaki/translator/shakujo_translator_test.cpp)
+    add_test_executable(mizugaki/translator/details/type_info_translator_test.cpp)
+    add_test_executable(mizugaki/translator/details/value_info_translator_test.cpp)
+    add_test_executable(mizugaki/translator/details/type_translator_test.cpp)
+    add_test_executable(mizugaki/translator/details/scalar_expression_translator_test.cpp)
+    add_test_executable(mizugaki/translator/details/relation_expression_translator_test.cpp)
+    add_test_executable(mizugaki/translator/details/dml_statement_translator_test.cpp)
+    add_test_executable(mizugaki/translator/details/ddl_statement_translator_test.cpp)
+endif (ENABLE_SHAKUJO)


### PR DESCRIPTION
This PR introduces a new CMake option `-DENABLE_SHAKUJO=OFF` to disable shakujo translator.
Disabling it, the build may no longer require shakujo installation.

Note that, the option is transitive: it will be removed after the tsurugi does not require shakujo.