### PR TITLE
ci: remove Shakujo in CI workflow

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -29,15 +29,6 @@ runs:
         ref: master
         submodules: true
 
-    - name: Checkout_Shakujo
-      if: ${{ inputs.checkout == 'true' }}
-      uses: actions/checkout@v4
-      with:
-        repository: project-tsurugi/shakujo
-        path: ${{ inputs.path }}/shakujo
-        ref: master
-        submodules: recursive
-
     - name: Install_Takatori
       run: |
         cd ${{ inputs.path }}/takatori
@@ -65,15 +56,5 @@ runs:
         mkdir build
         cd build
         cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DFORCE_INSTALL_RPATH=ON -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ..
-        cmake --build . --target install --clean-first
-      shell: bash
-
-    - name: Install_Shakujo
-      run: |
-        cd ${{ inputs.path }}/shakujo
-        rm -fr build
-        mkdir build
-        cd build
-        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DBUILD_EXAMPLES=OFF -DFORCE_INSTALL_RPATH=ON -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ..
         cmake --build . --target install --clean-first
       shell: bash


### PR DESCRIPTION
Remove Shakujo, which was built as a dependency in the CI workflow.