### PR TITLE
suppress warinings to compile bison output (for FTBFS with clang 15)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,6 +32,12 @@ ADD_FLEX_BISON_DEPENDENCY(
     sql_parser
 )
 
+set_source_files_properties(
+    ${BISON_sql_parser_OUTPUTS}
+    PROPERTIES
+    COMPILE_OPTIONS -Wno-unused-but-set-variable
+)
+
 add_library(mizugaki
 
     # AST models


### PR DESCRIPTION
bison の出力ファイルが LLVM 15 以降の clang でコンパイル警告 (+ `-Werror` でエラー) になる問題の修正です。